### PR TITLE
[MEET-107] Fully implemented controllers/services to handle active/inactive posts

### DIFF
--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/ClientController.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/ClientController.java
@@ -3,7 +3,6 @@ package com.meetapp.meetapp.controller;
 import com.meetapp.meetapp.dto.CategoryListDTO;
 import com.meetapp.meetapp.model.Category;
 import com.meetapp.meetapp.model.Client;
-import com.meetapp.meetapp.model.Post;
 import com.meetapp.meetapp.service.ClientService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -68,12 +67,17 @@ public class ClientController {
     public List<Record> getClientPosts(HttpSession session) {
         return clientService.retrieveClientPosts(session);
     }
-    
+
+    @GetMapping("/users/postsInactive")
+    public List<Record> getClientInactivePosts(HttpSession session) {
+        return clientService.retrieveClientInactivePosts(session);
+    }
+
     @GetMapping("/users/activities")
     public List<Record> getClientActivities(HttpSession session) {
         return clientService.retrieveLoggedInUserActivities(session);
     }
-    
+
     @GetMapping("/users/isAuthor/{postId}")
     public boolean isLoggedUserAuthorOfPost(HttpSession session, @PathVariable Integer postId) {
         return clientService.isLoggedUserAuthorOfPost(session, postId);

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/EventController.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/EventController.java
@@ -47,7 +47,15 @@ public class EventController {
                                     @RequestParam(required = false) List<Integer> locationIds,
                                     @RequestParam(required = false) Integer sortOption,
                                     @RequestParam(required = false) String nameSearch) {
-        return eventService.retrieveEvents(categoryIds, locationIds, sortOption, nameSearch);
+        return eventService.retrieveEvents(categoryIds, locationIds, sortOption, nameSearch, true);
+    }
+
+    @GetMapping("/eventsInactive")
+    public List<EventDTO> getInactiveEvents(@RequestParam(required = false) List<Integer> categoryIds,
+                                    @RequestParam(required = false) List<Integer> locationIds,
+                                    @RequestParam(required = false) Integer sortOption,
+                                    @RequestParam(required = false) String nameSearch) {
+        return eventService.retrieveEvents(categoryIds, locationIds, sortOption, nameSearch, false);
     }
 
     @GetMapping("/events/{eventId}")

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/PostController.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/controller/PostController.java
@@ -1,0 +1,40 @@
+package com.meetapp.meetapp.controller;
+
+import com.meetapp.meetapp.dto.PostDTO;
+import com.meetapp.meetapp.service.PostService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api")
+public class PostController {
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNotFound(NoSuchElementException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<String> handleUnauthorized(Exception e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @GetMapping("/posts/activate/{postId}")
+    public PostDTO activatePost(@PathVariable Integer postId, HttpSession session) {
+        return postService.activatePost(postId, session);
+    }
+
+    @GetMapping("/posts/deactivate/{postId}")
+    public PostDTO deactivatePost(@PathVariable Integer postId, HttpSession session) {
+        return postService.deactivatePost(postId, session);
+    }
+}

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/repository/PostRepository.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
-    List<Post> findAllByAuthorEmailIs(String email);
+    List<Post> findAllByAuthorEmailIsAndIsActiveIs(String email, Boolean isActive);
+
     List<Post> findAllByEnrolleesContains(Client enrollee);
 }

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/AnnouncementService.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/AnnouncementService.java
@@ -39,7 +39,7 @@ public class AnnouncementService {
     public List<AnnouncementDTO> retrieveAnnouncements(List<Integer> categoryIds, List<Integer> locationIds,
                                                        Integer sortOption, String nameSearch) {
 
-        Specification<Announcement> specification = Specification.where(null);
+        Specification<Announcement> specification = Specification.where(AnnouncementSpecifications.isActive());
 
         if (categoryIds != null) {
             specification = specification.and(AnnouncementSpecifications.hasCategory(categoryIds));

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/ClientService.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/ClientService.java
@@ -46,19 +46,24 @@ public class ClientService {
     }
 
     public List<Record> retrieveClientPosts(Integer clientId) {
-        return postRepository.findAllByAuthorEmailIs(findClientOrThrow(clientId).getEmail())
+        return postRepository.findAllByAuthorEmailIsAndIsActiveIs(findClientOrThrow(clientId).getEmail(), true)
                 .stream().map(ClientService::postToDto).toList();
     }
 
     public List<Record> retrieveClientPosts(HttpSession session) {
-        return postRepository.findAllByAuthorEmailIs(SessionManager.retrieveEmailOrThrow(session))
+        return postRepository.findAllByAuthorEmailIsAndIsActiveIs(SessionManager.retrieveEmailOrThrow(session), true)
                 .stream().map(ClientService::postToDto).toList();
     }
-    
+
+    public List<Record> retrieveClientInactivePosts(HttpSession session) {
+        return postRepository.findAllByAuthorEmailIsAndIsActiveIs(SessionManager.retrieveEmailOrThrow(session), false)
+                .stream().map(ClientService::postToDto).toList();
+    }
+
     public Client retrieveClientDetails(Integer clientId) {
         return findClientOrThrow(clientId);
     }
-    
+
     public List<Record> retrieveLoggedInUserActivities(HttpSession session) {
         Client loggedUser = findClientOrThrow(SessionManager.retrieveEmailOrThrow(session));
         return postRepository.findAllByEnrolleesContains(loggedUser).stream().map((Post post) -> {

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/EventService.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/EventService.java
@@ -43,8 +43,15 @@ public class EventService {
     }
 
     public List<EventDTO> retrieveEvents(List<Integer> categoryIds, List<Integer> locationIds,
-                                         Integer sortOption, String nameSearch) {
-        Specification<Event> specification = Specification.where(null);
+                                         Integer sortOption, String nameSearch, Boolean shouldDisplayActive) {
+
+        Specification<Event> specification;
+
+        if (shouldDisplayActive) {
+            specification = Specification.where(EventSpecifications.isActive());
+        } else {
+            specification = Specification.where(EventSpecifications.isInactive());
+        }
 
         if (categoryIds != null) {
             specification = specification.and(EventSpecifications.hasCategory(categoryIds));

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/MeetingService.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/MeetingService.java
@@ -39,7 +39,7 @@ public class MeetingService {
     public List<MeetingDTO> retrieveMeetings(List<Integer> categoryIds, List<Integer> locationIds,
                                              Integer sortOption, String nameSearch) {
 
-        Specification<Meeting> specification = Specification.where(null);
+        Specification<Meeting> specification = Specification.where(MeetingSpecifications.isActive());
 
         if (categoryIds != null) {
             specification = specification.and(MeetingSpecifications.hasCategory(categoryIds));

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/PostService.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/service/PostService.java
@@ -1,8 +1,83 @@
 package com.meetapp.meetapp.service;
 
+import com.meetapp.meetapp.dto.PostDTO;
+import com.meetapp.meetapp.model.*;
+import com.meetapp.meetapp.repository.*;
+import com.meetapp.meetapp.security.SessionManager;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
 
 @Service
 public class PostService {
+    
+    private final PostRepository postRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final MeetingRepository meetingRepository;
+    private final EventRepository eventRepository;
+    private final ClientRepository clientRepository;
+    
+    public PostService(PostRepository postRepository, AnnouncementRepository announcementRepository,
+                       MeetingRepository meetingRepository, EventRepository eventRepository,
+                       ClientRepository clientRepository) {
+        this.postRepository = postRepository;
+        this.announcementRepository = announcementRepository;
+        this.meetingRepository = meetingRepository;
+        this.eventRepository = eventRepository;
+        this.clientRepository = clientRepository;
+    }
+    
+    public PostDTO activatePost(Integer postId, HttpSession session) {
+        Post foundPost = findPostOrThrow(postId);
+        Client foundClient = findClientOrThrow(SessionManager.retrieveEmailOrThrow(session));
 
+        if (foundPost.getAuthor().equals(foundClient)) {
+            if (foundPost instanceof Announcement a) {
+                a.setCreationDate(LocalDate.now(ZoneId.of("UTC")));
+                a.setIsActive(true);
+                announcementRepository.save(a);
+            } else if (foundPost instanceof Meeting m) {
+                if (Instant.now().isBefore(m.getMeetingDate())) {
+                    m.setIsActive(true);
+                    meetingRepository.save(m);
+                }
+            } else {
+                Event casted = (Event) foundPost;
+                if (Instant.now().isBefore(casted.getStartDate())) {
+                    casted.setIsActive(true);
+                    eventRepository.save(casted);
+                }
+            }
+        }
+
+        return new PostDTO(foundPost);
+    }
+    
+    public PostDTO deactivatePost(Integer postId, HttpSession session) {
+        Post foundPost = findPostOrThrow(postId);
+        Client foundClient = findClientOrThrow(SessionManager.retrieveEmailOrThrow(session));
+
+        if (foundPost.getAuthor().equals(foundClient)) {
+            foundPost.setIsActive(false);
+            foundPost.setEnrolled(0);
+            foundPost.setEnrollees(new HashSet<>());
+        }
+
+        return new PostDTO(postRepository.save(foundPost));
+    }
+    
+    public Post findPostOrThrow(Integer postId) {
+        return postRepository.findById(postId).orElseThrow(
+                () -> new NoSuchElementException("A post with id: " + postId + " does not exist."));
+    }
+
+    public Client findClientOrThrow(String email) {
+        return clientRepository.findClientByEmail(email).orElseThrow(
+                () -> new NoSuchElementException("A client with email: " + email + " does not exist."));
+    }
 }

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/AnnouncementSpecifications.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/AnnouncementSpecifications.java
@@ -29,4 +29,8 @@ public class AnnouncementSpecifications {
     public static Specification<Announcement> titleContains(String searchedPhrase) {
         return (announcement, cq, cb) -> cb.like(cb.lower(announcement.get("title")), "%" + searchedPhrase.toLowerCase() + "%");
     }
+
+    public static Specification<Announcement> isActive() {
+        return (announcement, cq, cb) -> cb.isTrue(announcement.get("isActive"));
+    }
 }

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/EventSpecifications.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/EventSpecifications.java
@@ -29,4 +29,12 @@ public class EventSpecifications {
     public static Specification<Event> titleContains(String searchedPhrase) {
         return (event, cq, cb) -> cb.like(cb.lower(event.get("title")), "%" + searchedPhrase.toLowerCase() + "%");
     }
+
+    public static Specification<Event> isActive() {
+        return (event, cq, cb) -> cb.isTrue(event.get("isActive"));
+    }
+
+    public static Specification<Event> isInactive() {
+        return (event, cq, cb) -> cb.isFalse(event.get("isActive"));
+    }
 }

--- a/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/MeetingSpecifications.java
+++ b/backend/MeetApp/src/main/java/com/meetapp/meetapp/specification/MeetingSpecifications.java
@@ -29,4 +29,8 @@ public class MeetingSpecifications {
     public static Specification<Meeting> titleContains(String searchedPhrase) {
         return (meeting, cq, cb) -> cb.like(cb.lower(meeting.get("title")), "%" + searchedPhrase.toLowerCase() + "%");
     }
+
+    public static Specification<Meeting> isActive() {
+        return (meeting, cq, cb) -> cb.isTrue(meeting.get("isActive"));
+    }
 }


### PR DESCRIPTION
Tested with Postman that only logged in user can freely activate/deactivate his posts. Also, deactivated posts don't show up when sending GET /announcements for example.